### PR TITLE
Prevent endless loop when building production LESS code

### DIFF
--- a/less/less_engine.js
+++ b/less/less_engine.js
@@ -3104,6 +3104,10 @@
 		location.protocol === 'chrome-extension:'  ||
 		location.protocol === 'resource:');
 
+	if (steal && steal.isRhino) {
+		less.env = 'production';
+	}
+
 	less.env = less.env || (location.hostname == '127.0.0.1' ||
 		location.hostname == '0.0.0.0'   ||
 		location.hostname == 'localhost' ||


### PR DESCRIPTION
Our production builds were hanging at the last step, compiling CSS, because Rhino was waiting for all timers to end. This wasn't happening, because the LESS engine running in the (headless) browser was running in an infinite loop - this is how it monitors for newly-loaded LESS files. The client-side LESS engine was performing this monitor, because it was being run in development mode always - even when running in Rhino during the production build.

This change checks if running in Rhino and, if so, explicitly sets the environment to "production".
